### PR TITLE
Fix sonyflake initialization issue by using AmazonEC2MachineID as Mac…

### DIFF
--- a/common/snowflakeid.go
+++ b/common/snowflakeid.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/sony/sonyflake"
+	"github.com/sony/sonyflake/awsutil"
 )
 
 // snowflakeGenerator 单例
@@ -36,7 +37,12 @@ func initGenerator() {
 	}
 	flake := sonyflake.NewSonyflake(st)
 	if flake == nil {
-		FatalLog("sonyflake not created")
+		// fix: no private ip address, use AmazonEC2MachineID as Settings.MachineID
+		st.MachineID = awsutil.AmazonEC2MachineID
+		flake = sonyflake.NewSonyflake(st)
+		if flake == nil {
+			FatalLog("sonyflake not created")
+		}
 	}
 	generator = &SnowflakeGenerator{
 		flake: flake,


### PR DESCRIPTION
没有使用docker形式部署，而是直接编译形式运行cdp，在VPS由于`no private ip address`导致程序报错`[FATAL] 2024/03/15 - 09:00:05 | [sonyflake not created] `，修改在初始化sonyflake失败后，尝试使用[awsutil](https://github.com/sony/sonyflake/blob/master/awsutil)的方法 AmazonEC2MachineID 作为 Settings.MachineID。